### PR TITLE
[Feat] Authenticate github signatures

### DIFF
--- a/labelbot/bot.py
+++ b/labelbot/bot.py
@@ -4,12 +4,16 @@ import python_jwt
 import os
 import boto3
 import botocore
+import hmac
+import hashlib
 from labelbot import auth
 from labelbot import github_api
 from labelbot import parse
 
 
 def lambda_handler(event, context):
+    headers = json.loads(event["headers"])
+    auth_header = headers.get("X-Hub-Signature")
     body = json.loads(event["body"])
     installation_id = body["installation"]["id"]
     owner = body["repository"]["owner"]["login"]
@@ -19,6 +23,8 @@ def lambda_handler(event, context):
     current_labels = [label["name"] for label in body["issue"]["labels"]]
 
     app_id = int(os.environ["APP_ID"])
+    secret_key = os.environ["SECRET_KEY"]
+    authenticated = authenticate_request(secret_key, body, auth_header)
     bucket_name = os.environ["BUCKET_NAME"]
     bucket_key = os.environ["BUCKET_KEY"]
     pem = get_pem(bucket_name, bucket_key)
@@ -40,3 +46,13 @@ def get_pem(bucket_name, key):
     with open("/tmp/key.pem", "rb") as f:
         pem = f.read()
     return pem
+
+def authenticate_request(key: str, body: str, signature: str) -> bool:
+    """ Chacks if the X-Hub-Signature header exists, and if it does, verifies that the body 
+    matches the hash sent from github."""
+    if signature is None:
+        return False
+    
+    sha_body = hmac.new(key.encode("utf8"), body.encode("utf8"), hashlib.sha1).hexdigest()
+    alg, sha_github = signature.split("=")
+    return hmac.compare_digest(sha_body, sha_github)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,16 @@
+from labelbot import bot
+SECRET = "d653a60adc0a16a93e99f0620a67f4a67ef901df"
+BODY = "Hello, World!"
+SIGN = "sha1=8727505c9c036b2337a06d2e63f091a7aa41ae60"
+
+def test_correct_hash():
+    result = bot.authenticate_request(SECRET,BODY, SIGN)
+    assert result
+
+def test_incorrect_hash():
+    result = bot.authenticate_request(SECRET,BODY.lower(), SIGN)
+    assert not result
+
+def test_no_signature():
+    result = bot.authenticate_request(SECRET,BODY, None)
+    assert not result


### PR DESCRIPTION
Also adds test for the authenticate_requests method.
Fixes #27 